### PR TITLE
update tabs-newtab-button margins

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -244,13 +244,9 @@ input#urlbar-input {
 
 
 toolbarbutton#tabs-newtab-button {
-
 	background-image: none !important;
-	
 	padding-left: 10px !important;
-	
-	margin: -10px !important;
-	
+	margin-left: -10px !important;
 }
 
 /* remove space before the first tab */


### PR DESCRIPTION
fixes tab overflow bug by removing changes to all margins besides left, with no changes to UI

Unsure if this issue is present in other systems, but I was having issues with tab overflow on my Arch Linux build. See my reddit post [here](https://www.reddit.com/r/FirefoxCSS/comments/g6fl7o/how_can_i_prevent_the_overflow_tab_menu_from/) for details.